### PR TITLE
feat: add getProxyOf method to service

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run release
+      - run: npm run semantic-release
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </div>
 <br />
 
-> :warning: **Attention:** To support NestJS v8 and v9, this library will keep two stable versions. For NestJS v7, use `0.x` version.
+> :warning: **Attention:** For NestJS v7, this library will maintain `0.x` version in maintenance mode only. The `1.x` version supports NestJS v8 or later.
 
 ## Description
 
@@ -121,6 +121,11 @@ await this.extendedConfigService.load(true);
 // get an environment variable
 const dbUser = this.extendedConfigService.get<string>('DATABASE_USER');
 
+// get a proxy of an object from environment variable
+const appConfig = this.extendedConfigService.getProxyOf<
+	Record<string, unknown>
+>('APP_CONFIG');
+
 // verify if an environment variable exists
 const hasPassword = this.extendedConfigService.has('DATABASE_USER');
 
@@ -130,6 +135,8 @@ await this.extendedConfigService.reload();
 // reload environment variables for a specific strategy that allows reload
 await this.extendedConfigService.reload('STRATEGY_IDENTIFIER');
 ```
+
+> :warning: **Important:** `getProxyOf()` method only returns a proxy when returned value is an object, in any other cases, it will return the value directly. If you need a non-object value from the proxy, try encapsulate it with a transformer.
 
 ## Full example
 

--- a/lib/extended-config.service.ts
+++ b/lib/extended-config.service.ts
@@ -123,6 +123,28 @@ export class ExtendedConfigService<K = Record<string, any>> {
 		return defaultValue;
 	}
 
+	/**
+	 * Method that retrieve a proxy of an environment variable given a key.
+	 *
+	 * @param propertyPath property path (key) associated with the desired variable.
+	 * @param defaultValue optional default variable to be returned if the service does not have the requested variable.
+	 */
+	getProxyOf<T = any>(propertyPath: keyof K, defaultValue?: T): T | undefined {
+		const baseTarget = this.get<T>(propertyPath, defaultValue);
+
+		if (baseTarget && typeof baseTarget === 'object')
+			return new Proxy(baseTarget as T & object, {
+				get: (_target, property: string) => {
+					const target: Record<string, unknown> =
+						this.get<T>(propertyPath, defaultValue) || {};
+
+					return target?.[property];
+				},
+			}) as T;
+
+		return baseTarget;
+	}
+
 	private getFromCache<T = any>(propertyPath: keyof K): T | undefined {
 		return getFrom(this.cache, propertyPath);
 	}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --runInBand --coverage",
     "prerelease": "npm run build",
-    "release": "npm publish --access=public"
+    "release": "npm publish --access=public",
+    "semantic-release": "semantic-release"
   },
   "dependencies": {
     "dotenv": "8.2.0",
@@ -51,7 +52,8 @@
     "rimraf": "3.0.2",
     "ts-jest": "26.4.4",
     "tslint": "^6.1.3",
-    "typescript": "4.1.3"
+    "typescript": "4.1.3",
+    "semantic-release": "^19.0.3"
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0",

--- a/tests/e2e/with-strategy-using-functions.spec.ts
+++ b/tests/e2e/with-strategy-using-functions.spec.ts
@@ -450,4 +450,48 @@ describe('With strategy using functions', () => {
 	afterEach(async () => {
 		await app.close();
 	});
+
+	it.only(`should load variables from strategy using functions and return latest value from getProxyOf after a reload`, async () => {
+		const variablesBeforeReload = {
+			obj: { number: 0, string: 'foo' },
+		};
+		const variablesAfterReload = {
+			obj: { number: 1, string: 'bar' },
+		};
+		const loader = jest
+			.fn()
+			.mockResolvedValueOnce(variablesBeforeReload)
+			.mockResolvedValueOnce(variablesAfterReload);
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				AppModule.withStrategy([
+					{
+						identifier: 'LOADER_FUNCTION',
+						reloadable: true,
+						loader,
+					},
+				]),
+			],
+		}).compile();
+
+		app = moduleRef.createNestApplication();
+		await app.init();
+
+		expect(loader).toHaveBeenCalledTimes(1);
+
+		const service = app.get<ExtendedConfigService>(ExtendedConfigService);
+
+		const objectFromConfig = service.getProxyOf('obj');
+
+		expect(objectFromConfig).toMatchObject(variablesBeforeReload.obj);
+		expect(objectFromConfig.number).toBe(variablesBeforeReload.obj.number);
+		expect(objectFromConfig.string).toBe(variablesBeforeReload.obj.string);
+
+		await service.reload();
+
+		expect(objectFromConfig).toMatchObject(variablesAfterReload.obj);
+		expect(objectFromConfig.number).toBe(variablesAfterReload.obj.number);
+		expect(objectFromConfig.string).toBe(variablesAfterReload.obj.string);
+	});
 });

--- a/tests/e2e/with-strategy-using-functions.spec.ts
+++ b/tests/e2e/with-strategy-using-functions.spec.ts
@@ -451,7 +451,7 @@ describe('With strategy using functions', () => {
 		await app.close();
 	});
 
-	it.only(`should load variables from strategy using functions and return latest value from getProxyOf after a reload`, async () => {
+	it(`should load variables from strategy using functions and return freshest value from an object-based variable with getProxyOf after a reload`, async () => {
 		const variablesBeforeReload = {
 			obj: { number: 0, string: 'foo' },
 		};
@@ -493,5 +493,46 @@ describe('With strategy using functions', () => {
 		expect(objectFromConfig).toMatchObject(variablesAfterReload.obj);
 		expect(objectFromConfig.number).toBe(variablesAfterReload.obj.number);
 		expect(objectFromConfig.string).toBe(variablesAfterReload.obj.string);
+	});
+
+	it(`should load variables from strategy using functions and return first value from a non object-based variable with getProxyOf after a reload`, async () => {
+		const variablesBeforeReload = {
+			string: 'foo',
+		};
+		const variablesAfterReload = {
+			string: 'bar',
+		};
+		const loader = jest
+			.fn()
+			.mockResolvedValueOnce(variablesBeforeReload)
+			.mockResolvedValueOnce(variablesAfterReload);
+
+		const moduleRef = await Test.createTestingModule({
+			imports: [
+				AppModule.withStrategy([
+					{
+						identifier: 'LOADER_FUNCTION',
+						reloadable: true,
+						loader,
+					},
+				]),
+			],
+		}).compile();
+
+		app = moduleRef.createNestApplication();
+		await app.init();
+
+		expect(loader).toHaveBeenCalledTimes(1);
+
+		const service = app.get<ExtendedConfigService>(ExtendedConfigService);
+
+		const objectFromConfig = service.getProxyOf('string');
+
+		expect(objectFromConfig).toBe(variablesBeforeReload.string);
+
+		await service.reload();
+
+		expect(objectFromConfig).toBe(variablesBeforeReload.string);
+		expect(objectFromConfig).not.toBe(variablesAfterReload.string);
 	});
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When you inject a configuration object as a singleton on NestJS module, this object will never be reloaded, even if library reload it on strategy. To avoid this behavior actually you need to inject `ExtendedConfigService` directly on your service and call `get()` method everytime you need an environment variable. That could not be a big deal, but this solution adds an unnecessary coupling to your service.

Example:
- Environment variables on first load (with transformer):
```json
{
	"app_config": {
		"enableSomeFeature": false
	}
}
```

- Singleton that will receive the configuration values
```typescript
{
	provide: 'APP_CONFIG',
	useFactory: (configService: ExtendedConfigService) => {
		return configService.get('app_config');
	},
	inject: [ExtendedConfigService],
}
```

- Environment variables after a reload (with transformer):
```json
{
	"app_config": {
		"enableSomeFeature": true
	}
}
```

- Sample service
```typescript
import { Injectable } from '@nestjs/common';

@Injectable()
import { Inject, Injectable } from '@nestjs/common';
import { AppConfig } from '@config/config';

@Injectable()
export class AuthService {
	constructor(@Inject('APP_CONFIG') private readonly appConfig: AppConfig) {}

	isFeatureEnabled(): boolean {
		return this.appConfig.enableSomeFeature; // Will always return false
	}
}
```

## What is the new behavior?
If your environment variable is an object, you can now use `getProxyOf()` method to receive a proxy for `get()` method instead of the variable directly, allowing you to always have the freshest value without any coupling.

Example:
- Environment variables on first load (with transformer):
```json
{
	"app_config": {
		"enableSomeFeature": false
	}
}
```

- Singleton that will receive the configuration values
```typescript
{
	provide: 'APP_CONFIG',
	useFactory: (configService: ExtendedConfigService) => {
		return configService.getProxyOf('app_config');
	},
	inject: [ExtendedConfigService],
}
```

- Environment variables after a reload (with transformer):
```json
{
	"app_config": {
		"enableSomeFeature": true
	}
}
```

- Sample service
```typescript
import { Injectable } from '@nestjs/common';

@Injectable()
import { Inject, Injectable } from '@nestjs/common';
import { AppConfig } from '@config/config';

@Injectable()
export class AuthService {
	constructor(@Inject('APP_CONFIG') private readonly appConfig: AppConfig) {}

	isFeatureEnabled(): boolean {
		return this.appConfig.enableSomeFeature; // Will return the freshest value
	}
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
`semantic-release` was also configured on this repository.